### PR TITLE
ビュー実装　ーグループ機能

### DIFF
--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -1,0 +1,107 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+  }
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}
+
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+  &__name {
+    float: left;
+  }
+  &__btn {
+
+    display: inline-block;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,5 +3,6 @@
 @import "font-awesome-sprockets";
 @import "./font-awesome";
 @import "./user";
+@import "./group";
 @import "./colors";
 @import "./flash";

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the groups controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,25 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  %form
+    .chat-group-form__errors
+      %h2
+        1件のエラーが発生しました。
+        %ul
+          %li エラーです
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+    .chat-group-form__field
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label チャットメンバー
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        %input.chat-group-form__action-btn{data-disable-with: "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,25 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  %form
+    .chat-group-form__errors
+      %h2
+        1件のエラーが発生しました。
+        %ul
+          %li エラーです
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+    .chat-group-form__field
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label チャットメンバー
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -6,7 +6,7 @@
       .top-items__icons
         = link_to edit_user_path(current_user) do
           = icon('fas', 'cog', class: "i")
-        = link_to "#" do
+        = link_to new_group_path do
           = icon('fas', 'edit', class: "i")
 
   .group-list


### PR DESCRIPTION
#What
- view/groupにedit.html.hamlとnew.html.hamlを配置
- asset/stylesheetに_message.scssを配置
- _message.scssをapplication.scssにインポート
- side-barのtop-itemsのリンク先にnew_group_pathを設定
- 画面右側のEditからのグループ編集画面へのリンクは未了

# Why
- グループ新規作成画面を描画するため